### PR TITLE
Cherry pick rocky patches to stein

### DIFF
--- a/ansible/group_vars/all/kolla
+++ b/ansible/group_vars/all/kolla
@@ -116,6 +116,8 @@ overcloud_container_image_regex_map:
     enabled: "{{ kolla_enable_barbican | bool }}"
   - regex: blazar
     enabled: "{{ kolla_enable_blazar | bool }}"
+  - regex: caso
+    enabled: "{{ kolla_enable_caso | bool }}"
   - regex: ceilometer
     enabled: "{{ kolla_enable_ceilometer | bool }}"
   - regex: ceph
@@ -341,6 +343,7 @@ kolla_enable_aodh: "no"
 kolla_enable_barbican: "no"
 kolla_enable_blazar: "no"
 kolla_enable_central_logging: "no"
+kolla_enable_caso: "no"
 kolla_enable_ceph: "no"
 kolla_enable_ceilometer: "no"
 # The chrony container is disabled by default because we enable an NTP daemon

--- a/ansible/roles/kolla-ansible/templates/overcloud-components.j2
+++ b/ansible/roles/kolla-ansible/templates/overcloud-components.j2
@@ -240,3 +240,6 @@ control
 
 [blazar:children]
 control
+
+[caso:children]
+monitoring

--- a/ansible/roles/kolla-ansible/templates/overcloud-services.j2
+++ b/ansible/roles/kolla-ansible/templates/overcloud-services.j2
@@ -530,3 +530,6 @@ storage
 
 [prometheus-elasticsearch-exporter:children]
 elasticsearch
+
+[prometheus-libvirt-exporter:children]
+compute

--- a/ansible/roles/kolla-ansible/templates/overcloud-services.j2
+++ b/ansible/roles/kolla-ansible/templates/overcloud-services.j2
@@ -521,5 +521,12 @@ monitoring
 [prometheus-openstack-exporter:children]
 monitoring
 
+[prometheus-mtail:children]
+monitoring
+control
+compute
+network
+storage
+
 [prometheus-elasticsearch-exporter:children]
 elasticsearch

--- a/ansible/roles/kolla-ansible/templates/overcloud-services.j2
+++ b/ansible/roles/kolla-ansible/templates/overcloud-services.j2
@@ -533,3 +533,6 @@ elasticsearch
 
 [prometheus-libvirt-exporter:children]
 compute
+
+[prometheus-jiralert:children]
+prometheus-alertmanager

--- a/ansible/roles/kolla-ansible/templates/overcloud-services.j2
+++ b/ansible/roles/kolla-ansible/templates/overcloud-services.j2
@@ -100,13 +100,13 @@ storage
 cinder
 
 [cinder-backup:children]
-storage
+cinder
 
 [cinder-scheduler:children]
 cinder
 
 [cinder-volume:children]
-storage
+cinder
 
 # Cloudkitty
 [cloudkitty-api:children]

--- a/ansible/roles/kolla-ansible/vars/main.yml
+++ b/ansible/roles/kolla-ansible/vars/main.yml
@@ -74,6 +74,7 @@ kolla_feature_flags:
   - aodh
   - barbican
   - blazar
+  - caso
   - ceilometer
   - central_logging
   - ceph


### PR DESCRIPTION
I obtained a list of patches by rebasing cumulus/rocky on openstack/stable/rocky, here are the notes:
```
pick 27ddaf1 Add Prometheus OpenStack and mtail exporter to services
pick 9eddbde Support custom keepalived config                                                     upstream
pick 219efbb Add ES exporter and libvirt exporter to overcloud services
pick a590f79 Support add Prometheus rules for alerting                                            no longer neeeded as rules for alerting are in prometheus dir upstream and not a rules subdir
pick a78a8fd Add support for caso
pick 66d14ad Use overlay2 as its more stable                                                      it is now possible to set the storage driver as any arbitrary string
pick f0ededd Default cinder to controllers
pick 5c8ba26 Support deploying Prometheus Jiralert
pick 27eae58 Support customising Prometheus config                                                upstream
pick 549346c Add Prometheus OpenStack and mtail exporter to services                              dupe
pick a9a64ea Support custom keepalived config                                                     dupe
pick 95f5df5 Add ES exporter and libvirt exporter to overcloud services                           dupe
pick 9350b8c Support add Prometheus rules for alerting                                            dupe
pick 67a6616 Add support for caso                                                                 dupe
pick 8438426 Default cinder to controllers                                                        dupe
pick 70aed4c Support deploying Prometheus Jiralert                                                dupe
pick b16adec Support customising Prometheus config                                                dupe
```